### PR TITLE
Support new crowdin credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Subset of Crowdin HTTP API.
 import Crowdin from 'crowdin-client';
 
 const crowdin = new Crowdin({
-  key: 'YOUR_KEY',
+  accountKey: 'YOUR_KEY',
+  login: 'YOUR_USERNAME',
   project: 'YOUR_PROJECT',
 });
 
@@ -27,7 +28,8 @@ const promise = crowdin.createOrUpdateVersionedFile(
 import Crowdin from 'crowdin-client';
 
 const crowdin = new Crowdin({
-  key: 'YOUR_KEY',
+  accountKey: 'YOUR_KEY',
+  login: 'YOUR_USERNAME',
   project: 'YOUR_PROJECT',
 });
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -28,18 +28,22 @@ class Crowdin {
   constructor(options) {
     this.options = options;
     if (!options.project) {
-      throw new Error('Key `project` should be specified and contained crowdin project ID.');
+      throw new Error('Key `project` should be specified and contain crowdin project ID.');
     }
-    if (!options.key) {
-      throw new Error('Key `key` should be specified and contained crowdin API key.\n' + `Check https://crowdin.com/project/${options.project}/settings#api`);
+    if (!options.accountKey) {
+      throw new Error('Key `accountKey` should be specified and contain crowdin account API key.\n' + `Check https://crowdin.com/project/${options.project}/settings#api`);
+    }
+    if (!options.login) {
+      throw new Error('Key `login` should be specified and contain crowdin account username.\n' + `Check https://crowdin.com/project/${options.project}/settings#api`);
     }
   }
 
   getEndpointUrl(path, params) {
-    const { project, key } = this.options;
+    const { project, accountKey, login } = this.options;
     const endpointUrl = new _url.URL(`https://api.crowdin.com/api/project/${project}/${path}`);
     endpointUrl.searchParams.set('json', 1);
-    endpointUrl.searchParams.set('key', key);
+    endpointUrl.searchParams.set('account-key', accountKey);
+    endpointUrl.searchParams.set('login', login);
     if (params) {
       Object.keys(params).map(name => endpointUrl.searchParams.set(name, params[name]));
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "crowdin-client",
   "description": "Crowdin HTTP client for node.js",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/4u/crowdin-client"

--- a/src/client.js
+++ b/src/client.js
@@ -14,21 +14,28 @@ export default class Crowdin {
   constructor(options) {
     this.options = options;
     if (!options.project) {
-      throw new Error('Key `project` should be specified and contained crowdin project ID.');
+      throw new Error('Key `project` should be specified and contain crowdin project ID.');
     }
-    if (!options.key) {
+    if (!options.accountKey) {
       throw new Error(
-        'Key `key` should be specified and contained crowdin API key.\n' +
+        'Key `accountKey` should be specified and contain crowdin account API key.\n' +
+        `Check https://crowdin.com/project/${options.project}/settings#api`,
+      );
+    }
+    if (!options.login) {
+      throw new Error(
+        'Key `login` should be specified and contain crowdin account username.\n' +
         `Check https://crowdin.com/project/${options.project}/settings#api`,
       );
     }
   }
 
   getEndpointUrl(path, params) {
-    const { project, key } = this.options;
+    const { project, accountKey, login } = this.options;
     const endpointUrl = new URL(`https://api.crowdin.com/api/project/${project}/${path}`);
     endpointUrl.searchParams.set('json', 1);
-    endpointUrl.searchParams.set('key', key);
+    endpointUrl.searchParams.set('account-key', accountKey);
+    endpointUrl.searchParams.set('login', login);
     if (params) {
       Object.keys(params).map(name => endpointUrl.searchParams.set(name, params[name]));
     }


### PR DESCRIPTION
Crowdin has changed credentials for API V1. Project keys are not supported in new projects, account key in combination with login should be used instead.

https://github.com/crowdin/crowdin-api-client-js/issues/76